### PR TITLE
Expose Build options publically

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ multicast-socket = { git = "https://github.com/bltavares/multicast-socket" }
 
 *Why not use a version/publish crates.io*: Currently it is using unpublished version of some packages (git versions), which are not allowed when publishing to crates.io. When the new versions are published, this could also be published.
 
+## Targets
+
+Main tier:
+
+- x86_64-unknown-linux-gnu
+- x86_64-pc-windows-msvc
+- x86_64-apple-darwin
+
+Cross tier:
+
+- armv7-unknown-linux-gnueabihf
+- aarch64-linux-android
+- mips-unknown-linux-musl
+- x86_64-unknown-linux-musl
+- aarch64-unknown-linux-gnu
 
 ## License
 

--- a/examples/mdns.rs
+++ b/examples/mdns.rs
@@ -3,6 +3,17 @@ use std::net::SocketAddrV4;
 
 fn main() {
     let mdns_multicast_address = SocketAddrV4::new([224, 0, 0, 251].into(), 5353);
+
+    // Validate that building with options works with the public API
+    let with_options = MulticastSocket::with_options(
+        mdns_multicast_address,
+        multicast_socket::all_ipv4_interfaces().unwrap(),
+        multicast_socket::MulticastOptions {
+            ..Default::default()
+        },
+    );
+    drop(with_options);
+
     let socket = MulticastSocket::all_interfaces(mdns_multicast_address)
         .expect("could not create and bind socket");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 #[cfg(windows)]
 mod win;
 #[cfg(windows)]
@@ -7,3 +9,19 @@ pub use win::*;
 mod unix;
 #[cfg(not(windows))]
 pub use unix::*;
+
+pub struct MulticastOptions {
+    pub read_timeout: Duration,
+    pub loopback: bool,
+    pub buffer_size: usize,
+}
+
+impl Default for MulticastOptions {
+    fn default() -> Self {
+        MulticastOptions {
+            read_timeout: Duration::from_secs(1),
+            loopback: true,
+            buffer_size: 512,
+        }
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,31 +2,14 @@ use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::os::unix::io::AsRawFd;
-use std::time::Duration;
 
 use socket2::{Domain, Protocol, Socket, Type};
 
 use nix::sys::socket as sock;
 use nix::sys::uio::IoVec;
 
-pub struct MulticastOptions {
-    pub read_timeout: Duration,
-    pub loopback: bool,
-    pub buffer_size: usize,
-}
-
-impl Default for MulticastOptions {
-    fn default() -> Self {
-        MulticastOptions {
-            read_timeout: Duration::from_millis(100),
-            loopback: false,
-            buffer_size: 512,
-        }
-    }
-}
-
 fn create_on_interfaces(
-    options: MulticastOptions,
+    options: crate::MulticastOptions,
     interfaces: Vec<Ipv4Addr>,
     multicast_address: SocketAddrV4,
 ) -> io::Result<MulticastSocket> {
@@ -134,7 +117,7 @@ impl MulticastSocket {
     pub fn with_options(
         multicast_address: SocketAddrV4,
         interfaces: Vec<Ipv4Addr>,
-        options: MulticastOptions,
+        options: crate::MulticastOptions,
     ) -> io::Result<Self> {
         create_on_interfaces(options, interfaces, multicast_address)
     }

--- a/src/win.rs
+++ b/src/win.rs
@@ -3,7 +3,6 @@ use std::mem;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::os::windows::prelude::*;
 use std::ptr;
-use std::time::Duration;
 
 use socket2::{Domain, Protocol, Socket, Type};
 
@@ -131,24 +130,8 @@ fn set_pktinfo(socket: RawSocket, payload: bool) -> io::Result<()> {
     unsafe { setsockopt(socket, IPPROTO_IP, IP_PKTINFO, payload as c_int) }
 }
 
-pub struct MulticastOptions {
-    pub read_timeout: Duration,
-    loopback: bool,
-    buffer_size: usize,
-}
-
-impl Default for MulticastOptions {
-    fn default() -> Self {
-        MulticastOptions {
-            read_timeout: Duration::from_millis(100),
-            loopback: false,
-            buffer_size: 512,
-        }
-    }
-}
-
 fn create_on_interfaces(
-    options: MulticastOptions,
+    options: crate::MulticastOptions,
     interfaces: Vec<Ipv4Addr>,
     multicast_address: SocketAddrV4,
 ) -> io::Result<MulticastSocket> {
@@ -228,7 +211,7 @@ impl MulticastSocket {
     pub fn with_options(
         multicast_address: SocketAddrV4,
         interfaces: Vec<Ipv4Addr>,
-        options: MulticastOptions,
+        options: crate::MulticastOptions,
     ) -> io::Result<Self> {
         create_on_interfaces(options, interfaces, multicast_address)
     }


### PR DESCRIPTION
When trying to use the windows version of the socket, I could not build
with the options.

This was an error where only the *Nix version had public fields to edit.

To fix this, the build options has been promoted to the root of the
crate, so it is used on both systems and they end up with the same
config.

This commit also adds an example on the mdns test to ensure it compiles
using the public methods available on all platforms.

It also changes the defaults of build options to listen to multicast
messages, as it is very common to have multiple processes listening on
the same pc.