### PR TITLE
Fix crash in release mode for mdns example

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -373,8 +373,8 @@ impl MulticastSocket {
             len: buf.len() as _,
         };
 
+        let mut control_buffer = [0; CONTROL_PKTINFO_BUFFER_SIZE];
         let control = if let Some(pkt_info) = pkt_info {
-            let mut control_buffer = [0; CONTROL_PKTINFO_BUFFER_SIZE];
             let hdr = CMSGHDR {
                 cmsg_len: CONTROL_PKTINFO_BUFFER_SIZE,
                 cmsg_level: IPPROTO_IP,


### PR DESCRIPTION
control_buffer was going out of scope

Closes #14