### PR TITLE
Refactor PR CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,30 @@
+# We could use `@actions-rs/cargo` Action ability to automatically install `cross` tool
+# in order to compile our application for some unusual targets.
+
+# Separated as another pipeline to avoid errors cancelling other targets until the cross issue is solved
+# Ref: https://github.com/bltavares/multicast-socket/issues/18
+
+on: [push, pull_request]
+
+name: Cross-compile android
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-linux-android
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target=${{ matrix.target }} --examples

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.67
           target: ${{ matrix.target }}
           override: true
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/cross_compile.yml
+++ b/.github/workflows/cross_compile.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         target:
           - armv7-unknown-linux-gnueabihf
-          - aarch64-linux-android
-          - mips-unknown-linux-musl
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
     steps:

--- a/.github/workflows/mips.yml
+++ b/.github/workflows/mips.yml
@@ -1,0 +1,28 @@
+# Since Rust 1.72+ MIPS is a Tier 3 platform, and there are many errors on the latest nightly to use -Z build-std.
+# So we pin it to 1.71 to produce valid targets
+# Ref: https://github.com/rust-lang/compiler-team/issues/648
+
+on: [push, pull_request]
+
+name: Cross-compile MIPS
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - mips-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.71
+          target: ${{ matrix.target }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target=${{ matrix.target }} --examples


### PR DESCRIPTION
Upstream tooling has several breaking changes that limit our ability to cross compile on CI.

- MIPS downgraged to Tier 3 and not providing rust-std pre-compilation
- MIPS having `-lunwind` errors on nightly when running `-Z build-std`
- Stable cross for Android lacking `-lunwind` on the container

This commit separate the problematic pipelines into their own workflow, so it does not interrupt the build matrix of stable cross compilation tools.

Furthermore, to alleviate the MIPS Tier 3 downgraged, we now pin the MIPS pipeline to Rust 1.71, which still had MIPS as Tier 2.